### PR TITLE
prevents empty string to be added as a list or list item

### DIFF
--- a/ShoppingList/src/org/openintents/shopping/ui/ShoppingActivity.java
+++ b/ShoppingList/src/org/openintents/shopping/ui/ShoppingActivity.java
@@ -1581,7 +1581,7 @@ public class ShoppingActivity extends DistributionLibraryFragmentActivity
 	 * Inserts new item from edit box into currently selected shopping list.
 	 */
 	private void insertNewItem() {
-		String newItem = mEditText.getText().toString();
+		String newItem = mEditText.getText().toString().trim();
 
 		// Only add if there is something to add:
 		if (newItem.compareTo("") != 0) {
@@ -2033,7 +2033,7 @@ public class ShoppingActivity extends DistributionLibraryFragmentActivity
 	 *         because user has not given any name.
 	 */
 	private boolean createNewList(String name) {
-
+		name=name.trim();
 		if (name.equals("")) {
 			// User has not provided any name
 			Toast.makeText(this, getString(R.string.please_enter_name),
@@ -2103,7 +2103,7 @@ public class ShoppingActivity extends DistributionLibraryFragmentActivity
 	 *         because user has not given any name.
 	 */
 	private boolean renameList(String newName) {
-
+		newName=newName.trim();
 		if (newName.equals("")) {
 			// User has not provided any name
 			Toast.makeText(this, getString(R.string.please_enter_name),
@@ -2259,6 +2259,7 @@ public class ShoppingActivity extends DistributionLibraryFragmentActivity
 	 * 
 	 * @param field
 	 */
+	@SuppressWarnings("deprecation")
 	void editItem(long itemId, long containsId, EditItemDialog.FieldType field) {
 		mItemUri = Uri.withAppendedPath(ShoppingContract.Items.CONTENT_URI, ""
 				+ itemId);
@@ -2727,7 +2728,6 @@ public class ShoppingActivity extends DistributionLibraryFragmentActivity
 					android.R.layout.simple_spinner_item,
 					new String[] { getString(R.string.no_shopping_provider) });
 			setSpinnerListAdapter(adapter);
-
 			return;
 		}
 
@@ -2735,7 +2735,6 @@ public class ShoppingActivity extends DistributionLibraryFragmentActivity
 			// We have to create default shopping list:
 			long listId = ShoppingUtils.getList(this,
 					getText(R.string.my_shopping_list).toString());
-
 			// Check if insertion really worked. Otherwise
 			// we may end up in infinite recursion.
 			if (listId < 0) {
@@ -2993,7 +2992,6 @@ public class ShoppingActivity extends DistributionLibraryFragmentActivity
 						android.R.layout.simple_dropdown_item_1line,
 						autocompleteItems);
 			}
-
 		}.execute(listId);
 	}
 
@@ -3285,6 +3283,7 @@ public class ShoppingActivity extends DistributionLibraryFragmentActivity
 		}
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public void onItemChanged() {
 		mItemsView.mCursorItems.requery();

--- a/ShoppingList/src/org/openintents/shopping/ui/dialog/EditItemDialog.java
+++ b/ShoppingList/src/org/openintents/shopping/ui/dialog/EditItemDialog.java
@@ -8,8 +8,13 @@ import org.openintents.shopping.library.provider.ShoppingContract.Items;
 import org.openintents.shopping.library.provider.ShoppingContract.Units;
 import org.openintents.shopping.library.util.PriceConverter;
 import org.openintents.shopping.library.util.ShoppingUtils;
+<<<<<<< HEAD
 import org.openintents.shopping.ui.PreferenceActivity;
 import org.openintents.shopping.ui.ItemStoresActivity;
+=======
+import org.openintents.shopping.ui.ItemStoresActivity;
+import org.openintents.shopping.ui.PreferenceActivity;
+>>>>>>> parent of 837efb7... Revert "No empty string can now be added as a list item"
 
 import android.app.AlertDialog;
 import android.app.Dialog;
@@ -32,6 +37,10 @@ import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.ArrayAdapter;
 import android.widget.AutoCompleteTextView;
+<<<<<<< HEAD
+=======
+import android.widget.Button;
+>>>>>>> parent of 837efb7... Revert "No empty string can now be added as a list item"
 import android.widget.EditText;
 import android.widget.FilterQueryProvider;
 import android.widget.ImageButton;
@@ -39,7 +48,11 @@ import android.widget.MultiAutoCompleteTextView;
 import android.widget.SimpleCursorAdapter;
 import android.widget.SimpleCursorAdapter.CursorToStringConverter;
 import android.widget.TextView;
+<<<<<<< HEAD
 import android.widget.Button;
+=======
+import android.widget.Toast;
+>>>>>>> parent of 837efb7... Revert "No empty string can now be added as a list item"
 
 public class EditItemDialog extends AlertDialog implements OnClickListener {
 
@@ -212,6 +225,7 @@ public class EditItemDialog extends AlertDialog implements OnClickListener {
 		/*
 		 * setButton(R.string.ok, new DialogInterface.OnClickListener() { public
 		 * void onClick(DialogInterface dialog, int whichButton) {
+<<<<<<< HEAD
 		 *
 		 * dialog.dismiss(); doTextEntryDialogAction(mTextEntryMenu, (Dialog)
 		 * dialog);
@@ -220,6 +234,16 @@ public class EditItemDialog extends AlertDialog implements OnClickListener {
 		 * DialogInterface.OnClickListener() { public void
 		 * onClick(DialogInterface dialog, int whichButton) {
 		 *
+=======
+		 * 
+		 * dialog.dismiss(); doTextEntryDialogAction(mTextEntryMenu, (Dialog)
+		 * dialog);
+		 * 
+		 * } }).setNegativeButton(R.string.cancel, new
+		 * DialogInterface.OnClickListener() { public void
+		 * onClick(DialogInterface dialog, int whichButton) {
+		 * 
+>>>>>>> parent of 837efb7... Revert "No empty string can now be added as a list item"
 		 * dialog.cancel(); } }).create();
 		 */
 
@@ -239,7 +263,11 @@ public class EditItemDialog extends AlertDialog implements OnClickListener {
 
 	/**
 	 * Set cursor to be requeried if item is changed.
+<<<<<<< HEAD
 	 *
+=======
+	 * 
+>>>>>>> parent of 837efb7... Revert "No empty string can now be added as a list item"
 	 * @param c
 	 */
 	public void setOnItemChangedListener(OnItemChangedListener listener) {


### PR DESCRIPTION
The changes in ShoppingActivity. java can be seen clearly, and a .trim() has been added at different variables.

In EditItmeDialog.java I have only made one change, added a condition 
if(!text.equalsIgnoreCase(""))
befor line no. 384 in the old file. What this does is that if a user while editting an item edits fields but makes the item name an empty string( which should not be possible), all changes are made but the itme name reamins as it was earlier.
