### PR TITLE
Always call fillItems

### DIFF
--- a/ShoppingList/src/org/openintents/shopping/ui/ShoppingActivity.java
+++ b/ShoppingList/src/org/openintents/shopping/ui/ShoppingActivity.java
@@ -1642,8 +1642,8 @@ public class ShoppingActivity extends DistributionLibraryFragmentActivity
 					if (debug)
 						Log.d(TAG, "set new list: " + listId);
 					setSelectedListId((int) listId);
-					mItemsView.fillItems(this, listId);
 				}
+				mItemsView.fillItems(this, listId);
 			}
 
 			int max = mExtraItems.size();


### PR DESCRIPTION
The fillItems has as side-effect that mListId is set in the 
ShoppingItemsViewer.
This field must be set to the correct list, otherwise the database
record of 'contains' will not get the correct list-id field.

The test TestShoppingActivity#testIntentAddItemsFromArrayList 
failed before this commit, and now passes.
