### PR TITLE
Always add received text as 'new' items

### DIFF
--- a/ShoppingList/src/org/openintents/shopping/ui/widget/ShoppingItemsView.java
+++ b/ShoppingList/src/org/openintents/shopping/ui/widget/ShoppingItemsView.java
@@ -1228,7 +1228,7 @@ public class ShoppingItemsView extends ListView {
 				+ mListId);
 		boolean resetQuantity = PreferenceActivity.getResetQuantity(getContext());
 		ShoppingUtils.addItemToList(getContext(), itemId, mListId, Status.WANT_TO_BUY,
-				priority, quantity, true, false, resetQuantity);
+				priority, quantity, true, true, resetQuantity);
 
 		fillItems(activity, mListId);
 


### PR DESCRIPTION
Text that is received from another app will now always be added
as new 'want_to_buy' items in the shoppinglist.  That seems to me
to be the most logical expectation from sharing text with a shopping list
app.

This fixes the following problem:
If I mark some of the items but not others, and then "clean list",
and then share the same note again, the items seem to come back as
checked instead of unchecked. That seems like it would be a problem
for workflows involving a cookbook app.
