### PR TITLE
List in widget

### DIFF
--- a/ShoppingList/AndroidManifest.xml
+++ b/ShoppingList/AndroidManifest.xml
@@ -253,15 +253,22 @@
                 <action android:name="org.openintents.shopping.widgets.ActionUnCheck" />
                 <action android:name="org.openintents.shopping.widgets.ActionPrevPage" />
                 <action android:name="org.openintents.shopping.widgets.ActionNextPage" />
-            </intent-filter>
+                <action android:name="org.openintents.shopping.widgets.ActionToggleState" />
+                </intent-filter>
             <meta-data android:name="android.appwidget.provider" android:resource="@xml/widget_check_items" />
         </receiver>
         <activity android:name=".widgets.CheckItemsWidgetConfig">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
-         	</intent-filter>
-     	</activity>
-        <meta-data android:value="false" android:name="hideMarketLink"/>
+            </intent-filter>
+        </activity>
+        <service
+            android:name="org.openintents.shopping.widgets.ListWidgetService"
+            android:enabled="true"
+            android:permission="android.permission.BIND_REMOTEVIEWS"
+            android:exported = "false" />
+
+		<meta-data android:value="false" android:name="hideMarketLink"/>
 	</application>	 
 	
 	<!-- required for MyBackupPro: -->

--- a/ShoppingList/AndroidManifest.xml
+++ b/ShoppingList/AndroidManifest.xml
@@ -250,6 +250,7 @@
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
                 <action android:name="org.openintents.shopping.widgets.ActionCheck" />
+                <action android:name="org.openintents.shopping.widgets.ActionUnCheck" />
                 <action android:name="org.openintents.shopping.widgets.ActionPrevPage" />
                 <action android:name="org.openintents.shopping.widgets.ActionNextPage" />
             </intent-filter>

--- a/ShoppingList/res/layout-v11/widget_check_items.xml
+++ b/ShoppingList/res/layout-v11/widget_check_items.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="fill_parent"
+	android:layout_height="fill_parent"
+	android:orientation="vertical"
+	android:gravity="top|fill_horizontal"
+	android:background="@drawable/widget_check_items">
+
+	<ImageButton
+		android:id="@+id/button_go_to_app"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:layout_alignParentLeft="true"
+		android:background="@null"
+		android:src="@drawable/ic_launcher_shoppinglist"/>
+
+	<TextView
+		android:id="@+id/list_name"
+		android:layout_width="match_parent"
+		android:layout_height="fill_parent"
+		android:layout_alignBottom="@id/button_go_to_app"
+		android:layout_marginLeft="5dp"
+		android:layout_toLeftOf="@+id/button_go_to_preferences"
+		android:layout_toRightOf="@id/button_go_to_app"
+		android:gravity="center_vertical"
+		android:text="@string/app_name"
+		android:textColor="@color/black"/>
+
+	<ImageButton
+		android:id="@+id/button_go_to_preferences"
+		android:layout_width="wrap_content"
+		android:layout_height="fill_parent"
+		android:layout_alignBottom="@id/button_go_to_app"
+		android:layout_alignParentRight="true"
+		android:background="@null"
+		android:src="@android:drawable/ic_menu_preferences"/>
+
+	<FrameLayout
+		android:layout_height="match_parent"
+		android:layout_width="match_parent"
+		android:layout_below="@id/button_go_to_app">
+
+		<ListView
+			android:id="@+id/items_list"
+			android:layout_height="match_parent"
+			android:layout_width="match_parent"
+			android:padding="10dp"/>
+
+		<TextView
+			android:id="@+id/empty_view"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:text="@string/no_items_available"
+			android:layout_gravity="center"
+			android:textAppearance="?android:attr/textAppearanceMedium"/>
+
+	</FrameLayout>
+
+</RelativeLayout>
+

--- a/ShoppingList/res/layout/widget_check_items.xml
+++ b/ShoppingList/res/layout/widget_check_items.xml
@@ -17,16 +17,18 @@
         <ImageButton
             android:id="@+id/button_go_to_app"
             android:layout_width="wrap_content"
-            android:layout_height="fill_parent"
+            android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
             android:background="@null"
             android:src="@drawable/ic_launcher_shoppinglist" />
 
         <TextView
             android:id="@+id/list_name"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="fill_parent"
+            android:layout_alignBottom="@id/button_go_to_app"
             android:layout_marginLeft="5dp"
+            android:layout_toLeftOf="@+id/button_go_to_preferences"
             android:layout_toRightOf="@id/button_go_to_app"
             android:gravity="center_vertical"
             android:text="@string/app_name"
@@ -36,10 +38,10 @@
             android:id="@+id/button_go_to_preferences"
             android:layout_width="wrap_content"
             android:layout_height="fill_parent"
-            android:background="@null"
+            android:layout_alignBottom="@id/button_go_to_app"
             android:layout_alignParentRight="true"
+            android:background="@null"
             android:src="@android:drawable/ic_menu_preferences" />
-        
     </RelativeLayout>
 
     <TextView

--- a/ShoppingList/res/layout/widget_item.xml
+++ b/ShoppingList/res/layout/widget_item.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="wrap_content"
+	android:textAppearance="?android:attr/textAppearanceMedium"
+	android:id="@+id/widget_item">
+</TextView>
+

--- a/ShoppingList/res/xml/widget_check_items.xml
+++ b/ShoppingList/res/xml/widget_check_items.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minHeight="250dp"
-    android:minWidth="250dp"
+    android:minHeight="180dp"
+    android:minWidth="180dp"
     android:updatePeriodMillis="0"
     android:initialLayout="@layout/widget_check_items"
     android:configure="org.openintents.shopping.widgets.CheckItemsWidgetConfig" 

--- a/ShoppingList/src/org/openintents/shopping/ui/ShoppingActivity.java
+++ b/ShoppingList/src/org/openintents/shopping/ui/ShoppingActivity.java
@@ -60,6 +60,7 @@ import org.openintents.shopping.widgets.CheckItemsWidget;
 import org.openintents.util.MenuIntentOptionsWithIcons;
 import org.openintents.util.ShakeSensorListener;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
@@ -670,16 +671,28 @@ public class ShoppingActivity extends DistributionLibraryFragmentActivity
 		updateWidgets();
 	}
 
+	@TargetApi(Build.VERSION_CODES.HONEYCOMB)
 	private void updateWidgets() {
 		AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(this);
-		int[] a = appWidgetManager.getAppWidgetIds(new ComponentName(this
-				.getPackageName(), CheckItemsWidget.class.getName()));
-		List<AppWidgetProviderInfo> b = appWidgetManager
-				.getInstalledProviders();
-		for (AppWidgetProviderInfo i : b) {
-			if (i.provider.getPackageName().equals(this.getPackageName())) {
-				a = appWidgetManager.getAppWidgetIds(i.provider);
-				new CheckItemsWidget().onUpdate(this, appWidgetManager, a);
+		if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.HONEYCOMB) {
+			int[] a = appWidgetManager.getAppWidgetIds(new ComponentName(this
+					.getPackageName(), CheckItemsWidget.class.getName()));
+			List<AppWidgetProviderInfo> b = appWidgetManager
+					.getInstalledProviders();
+			for (AppWidgetProviderInfo i : b) {
+				if (i.provider.getPackageName().equals(this.getPackageName())) {
+					a = appWidgetManager.getAppWidgetIds(i.provider);
+					new CheckItemsWidget().onUpdate(this, appWidgetManager, a);
+				}
+			}
+		} else {
+			List<AppWidgetProviderInfo> providers = appWidgetManager
+					.getInstalledProviders();
+			for (AppWidgetProviderInfo providerInfo : providers) {
+				int[] a = appWidgetManager
+						.getAppWidgetIds(providerInfo.provider);
+				appWidgetManager.notifyAppWidgetViewDataChanged(a,
+						R.id.items_list);
 			}
 		}
 	}

--- a/ShoppingList/src/org/openintents/shopping/widgets/CheckItemsWidgetConfig.java
+++ b/ShoppingList/src/org/openintents/shopping/widgets/CheckItemsWidgetConfig.java
@@ -7,6 +7,7 @@ import org.openintents.shopping.library.provider.ShoppingContract;
 import org.openintents.shopping.library.provider.ShoppingContract.Lists;
 import org.openintents.shopping.ui.PreferenceActivity;
 
+import android.annotation.TargetApi;
 import android.app.ListActivity;
 import android.appwidget.AppWidgetManager;
 import android.appwidget.AppWidgetProviderInfo;
@@ -14,14 +15,16 @@ import android.content.ComponentName;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.database.Cursor;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.ListView;
 import android.widget.SimpleCursorAdapter;
 
 public class CheckItemsWidgetConfig extends ListActivity {
-	private final static String PREFS = "check_items_widget";
+	public final static String PREFS = "check_items_widget";
 	private int mAppWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID;
+	private final static boolean isHoneyComb = Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB;
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
@@ -65,12 +68,16 @@ public class CheckItemsWidgetConfig extends ListActivity {
 		finish();
 	}
 
+	@TargetApi(Build.VERSION_CODES.HONEYCOMB)
 	private void updateWidgets() {
 		AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(this);
 		int[] a = appWidgetManager.getAppWidgetIds(new ComponentName(
 				getPackageName(), CheckItemsWidget.class.getName()));
 		List<AppWidgetProviderInfo> b = appWidgetManager
 				.getInstalledProviders();
+		if (isHoneyComb) {
+			appWidgetManager.notifyAppWidgetViewDataChanged(a, R.id.items_list);
+		}
 		for (AppWidgetProviderInfo i : b) {
 			if (i.provider.getPackageName().equals(getPackageName())) {
 				a = appWidgetManager.getAppWidgetIds(i.provider);

--- a/ShoppingList/src/org/openintents/shopping/widgets/ListWidgetService.java
+++ b/ShoppingList/src/org/openintents/shopping/widgets/ListWidgetService.java
@@ -1,0 +1,140 @@
+package org.openintents.shopping.widgets;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openintents.shopping.R;
+import org.openintents.shopping.library.provider.ShoppingContract;
+import org.openintents.shopping.library.provider.ShoppingContract.ContainsFull;
+
+import android.annotation.TargetApi;
+import android.appwidget.AppWidgetManager;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.database.Cursor;
+import android.os.Build;
+import android.os.Bundle;
+import android.widget.RemoteViews;
+import android.widget.RemoteViewsService;
+
+@TargetApi(Build.VERSION_CODES.HONEYCOMB)
+public class ListWidgetService extends RemoteViewsService {
+
+	public RemoteViewsService.RemoteViewsFactory onGetViewFactory(Intent p1) {
+
+		return new ItemsViewFactory(p1, getApplicationContext());
+	}
+
+	private class Item {
+		public String name;
+		public long id;
+		public boolean bought;
+	}
+
+	public class ItemsViewFactory implements RemoteViewsFactory {
+		private final Context context;
+		private List<Item> items = new ArrayList<Item>();
+		private int widgetID;
+
+		public ItemsViewFactory(Intent intent, Context context) {
+			this.context = context;
+			this.widgetID = intent.getIntExtra(
+					AppWidgetManager.EXTRA_APPWIDGET_ID,
+					AppWidgetManager.INVALID_APPWIDGET_ID);
+		}
+
+		private void fillItems() {
+			SharedPreferences sharedPreferences = context.getSharedPreferences(
+					CheckItemsWidgetConfig.PREFS, 0);
+			long listId = sharedPreferences.getLong(String.valueOf(widgetID),
+					-1);
+			items.clear();
+
+			Cursor cursor = CheckItemsWidget.fillItems(context, listId);
+			if (cursor.moveToFirst())
+
+				while (!cursor.isAfterLast()) {
+					Item item = new Item();
+					item.name = cursor.getString(cursor
+							.getColumnIndex(ContainsFull.ITEM_NAME));
+					item.id = cursor.getLong(cursor
+							.getColumnIndex(ContainsFull.ITEM_ID));
+					item.bought = cursor.getInt(cursor
+							.getColumnIndex(ContainsFull.STATUS)) == ShoppingContract.Status.BOUGHT;
+					items.add(item);
+					cursor.moveToNext();
+
+				}
+			cursor.close();
+		}
+
+		public void onCreate() {
+		}
+
+		public void onDataSetChanged() {
+			fillItems();
+		}
+
+		public void onDestroy() {
+
+		}
+
+		public int getCount() {
+			return items.size();
+		}
+
+		public RemoteViews getViewAt(int position) {
+			// Construct a remote views item based on the app widget item XML
+			// file,
+			// and set the text based on the position.
+			RemoteViews rv = new RemoteViews(context.getPackageName(),
+					R.layout.widget_item);
+			Item item = items.get(position);
+			rv.setTextViewText(R.id.widget_item, item.name);
+			if (item.bought) {
+				rv.setTextColor(R.id.widget_item, context.getResources()
+						.getColor(R.color.strikethrough));
+			} else {
+				rv.setTextColor(R.id.widget_item, context.getResources()
+						.getColor(R.color.black));
+			}
+
+			// Next, set a fill-intent, which will be used to fill in the
+			// pending intent template
+			// that is set on the collection view in ListItemsWidgetProvider.
+			Bundle extras = new Bundle();
+			extras.putLong(CheckItemsWidget.ITEM_ID, item.id);
+			extras.putBoolean(CheckItemsWidget.MARK_CHECKED,
+					!item.bought);
+			Intent fillInIntent = new Intent();
+			fillInIntent.putExtras(extras);
+			// Make it possible to distinguish the individual on-click
+			// action of a given item
+			rv.setOnClickFillInIntent(R.id.widget_item, fillInIntent);
+
+			return rv;
+		}
+
+		public RemoteViews getLoadingView() {
+			return new RemoteViews(context.getPackageName(),
+					R.layout.widget_item);
+		}
+
+		/**
+		 * 2 types of views: with dark foreground and light foreground
+		 */
+		public int getViewTypeCount() {
+			return 2;
+		}
+
+		public long getItemId(int p1) {
+			return items.get(p1).id;
+		}
+
+		public boolean hasStableIds() {
+			return true;
+		}
+
+	}
+}

--- a/ShoppingList/src/org/openintents/shopping/widgets/ListWidgetService.java
+++ b/ShoppingList/src/org/openintents/shopping/widgets/ListWidgetService.java
@@ -59,7 +59,7 @@ public class ListWidgetService extends RemoteViewsService {
 					item.name = cursor.getString(cursor
 							.getColumnIndex(ContainsFull.ITEM_NAME));
 					item.id = cursor.getLong(cursor
-							.getColumnIndex(ContainsFull.ITEM_ID));
+							.getColumnIndex(ContainsFull._ID));
 					item.bought = cursor.getInt(cursor
 							.getColumnIndex(ContainsFull.STATUS)) == ShoppingContract.Status.BOUGHT;
 					items.add(item);


### PR DESCRIPTION
This comes in place of my previous pull request (https://github.com/openintents/shoppinglist/pull/9), which can be closed (sorry, I couldn't figure out how to do that).

Compared to the previous pull request I removed the 'clean list' button from the widget, and also refactored it, so that I now use Build.VERSION instead of the bools.xml.  I wrote in that previous pull-request that the android 2 version seemed broken (the next/prev buttons didn't work), but I think that problem was actually caused by something I did, for in this version they do work.

What is changed in this branch is:
- Check an item in the widget doesn't make it disappear immediately, but grays it out (this gives better feedback as to what happenend, and gives the possibility of an undo)
- For android honeycomb or higher, the widget now uses a ListView.  This looks better (in my opinion), especially if multi-line items are used, and makes the next/prev buttons unnecessary.
- Some small changes to the layout of the widget: the buttons are aligned to the top now, the default size is smaller, so that it can also be displayed on (very) small phones.
