### PR TITLE
squid:S2131 - Primitives should not be boxed just for String conversion

### DIFF
--- a/ShoppingList/src/main/java/org/openintents/shopping/ui/ShoppingActivity.java
+++ b/ShoppingList/src/main/java/org/openintents/shopping/ui/ShoppingActivity.java
@@ -2160,11 +2160,10 @@ public class ShoppingActivity extends DistributionLibraryFragmentActivity
      * @param field
      */
     void editItem(long itemId, long containsId, EditItemDialog.FieldType field) {
-        mItemUri = Uri.withAppendedPath(ShoppingContract.Items.CONTENT_URI, ""
-                + itemId);
-        mListItemUri = Uri.withAppendedPath(mListUri, "" + itemId);
+        mItemUri = Uri.withAppendedPath(ShoppingContract.Items.CONTENT_URI, Long.toString(itemId));
+        mListItemUri = Uri.withAppendedPath(mListUri, Long.toString(itemId));
         mRelationUri = Uri.withAppendedPath(
-                ShoppingContract.Contains.CONTENT_URI, "" + containsId);
+                ShoppingContract.Contains.CONTENT_URI, Long.toString(containsId));
         mEditItemFocusField = field;
 
         showDialog(DIALOG_EDIT_ITEM);
@@ -2567,8 +2566,8 @@ public class ShoppingActivity extends DistributionLibraryFragmentActivity
 
         long listId = mCursorShoppingLists.getLong(mStringListFilterID);
 
-        mListUri = Uri.withAppendedPath(ShoppingContract.Lists.CONTENT_URI, ""
-                + listId);
+        mListUri = Uri.withAppendedPath(ShoppingContract.Lists.CONTENT_URI,
+                Long.toString(listId));
 
         getIntent().setData(mListUri);
 

--- a/ShoppingList/src/main/java/org/openintents/shopping/ui/ShoppingTotalsHandler.java
+++ b/ShoppingList/src/main/java/org/openintents/shopping/ui/ShoppingTotalsHandler.java
@@ -56,7 +56,7 @@ public class ShoppingTotalsHandler implements LoaderManager.LoaderCallbacks<Curs
         } else {
             if (mListId != listId) {
                 mListId = listId;
-                mCursorLoader.setUri(ShoppingContract.Subtotals.CONTENT_URI.buildUpon().appendPath("" + mListId).build());
+                mCursorLoader.setUri(ShoppingContract.Subtotals.CONTENT_URI.buildUpon().appendPath(Long.toString(mListId)).build());
             }
             manager.restartLoader(ShoppingActivity.LOADER_TOTALS , null, this);
         }
@@ -66,7 +66,7 @@ public class ShoppingTotalsHandler implements LoaderManager.LoaderCallbacks<Curs
     public Loader<Cursor> onCreateLoader(int id, Bundle args) {
         CursorLoader loader =  new CursorLoader(mActivity);
         loader.setProjection(ShoppingContract.Subtotals.PROJECTION);
-        loader.setUri(ShoppingContract.Subtotals.CONTENT_URI.buildUpon().appendPath("" + mListId).build());
+        loader.setUri(ShoppingContract.Subtotals.CONTENT_URI.buildUpon().appendPath(Long.toString(mListId)).build());
         return loader;
     }
 

--- a/ShoppingList/src/main/java/org/openintents/shopping/widgets/CheckItemsWidget.java
+++ b/ShoppingList/src/main/java/org/openintents/shopping/widgets/CheckItemsWidget.java
@@ -165,7 +165,7 @@ public class CheckItemsWidget extends AppWidgetProvider {
             Intent intentGoToApp = new Intent(context, ShoppingActivity.class);
             intentGoToApp.setAction(Intent.ACTION_VIEW);
             intentGoToApp.setData(Uri.withAppendedPath(
-                    ShoppingContract.Lists.CONTENT_URI, "" + listId));
+                    ShoppingContract.Lists.CONTENT_URI, Long.toString(listId)));
             PendingIntent pendingIntentGoToApp = PendingIntent.getActivity(
                     context, 0, intentGoToApp,
                     PendingIntent.FLAG_UPDATE_CURRENT);
@@ -175,8 +175,8 @@ public class CheckItemsWidget extends AppWidgetProvider {
 			 */
             String title = getTitle(
                     context,
-                    Uri.withAppendedPath(ShoppingContract.Lists.CONTENT_URI, ""
-                            + listId)
+                    Uri.withAppendedPath(ShoppingContract.Lists.CONTENT_URI, 
+                            Long.toString(listId))
             );
             views.setTextViewText(R.id.list_name, title);
             views.setOnClickPendingIntent(R.id.list_name, pendingIntentGoToApp);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2131 - Primitives should not be boxed just for "String" conversion

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2131

Please let me know if you have any questions.

M-Ezzat