### PR TITLE
squid:SwitchLastCaseIsDefaultCheck - switch statements should end wit…

### DIFF
--- a/ShoppingList/src/main/java/org/openintents/provider/Alert.java
+++ b/ShoppingList/src/main/java/org/openintents/provider/Alert.java
@@ -377,7 +377,8 @@ public class Alert {
                 case ALERT_DATE_TIME:
                     registerDateTimeAlert(cv);
                     break;
-
+                default:
+                    break;
             }
 
         }

--- a/ShoppingList/src/main/java/org/openintents/shopping/ui/AddLocationAlertActivity.java
+++ b/ShoppingList/src/main/java/org/openintents/shopping/ui/AddLocationAlertActivity.java
@@ -195,6 +195,8 @@ public class AddLocationAlertActivity extends Activity implements
                     mTags.setText(mTag.findTags(data.getDataString(), ", "));
                     addLocationAlert();
                     break;
+                default:
+                    break;
             }
         }
     }

--- a/ShoppingList/src/main/java/org/openintents/shopping/ui/ItemStoresActivity.java
+++ b/ShoppingList/src/main/java/org/openintents/shopping/ui/ItemStoresActivity.java
@@ -170,6 +170,8 @@ public class ItemStoresActivity extends Activity {
                             }
                         }
                 );
+            default:
+                break;
         }
         return super.onCreateDialog(id);
     }
@@ -185,6 +187,8 @@ public class ItemStoresActivity extends Activity {
 
             case DIALOG_RENAME_STORE:
                 ((NewStoreDialog) dialog).setName(getSelectedStoreName());
+                break;
+            default:
                 break;
         }
     }
@@ -202,6 +206,8 @@ public class ItemStoresActivity extends Activity {
 
             case MENU_DELETE_STORE:
                 deleteStoreConfirm();
+                break;
+            default:
                 break;
         }
 

--- a/ShoppingList/src/main/java/org/openintents/shopping/ui/ShoppingActivity.java
+++ b/ShoppingList/src/main/java/org/openintents/shopping/ui/ShoppingActivity.java
@@ -1464,6 +1464,8 @@ public class ShoppingActivity extends DistributionLibraryFragmentActivity
                         case QUANTITY:
                             values.put(Contains.QUANTITY, number);
                             break;
+                        default:
+                            break;
                     }
                     mItemsView.mCursorItems.moveToPosition(pos);
                     String containsId = mItemsView.mCursorItems
@@ -1820,6 +1822,8 @@ public class ShoppingActivity extends DistributionLibraryFragmentActivity
             case MENU_SYNC_WEAR:
                 mItemsView.pushItemsToWear();
                 return true;
+            default:
+                break;
         }
         if (debug) {
             Log.d(TAG, "Start intent group id : " + item.getGroupId());
@@ -1900,6 +1904,8 @@ public class ShoppingActivity extends DistributionLibraryFragmentActivity
                 break;
             case MENU_ITEM_STORES:
                 editItemStores(menuInfo.position);
+                break;
+            default:
                 break;
         }
 
@@ -2496,6 +2502,8 @@ public class ShoppingActivity extends DistributionLibraryFragmentActivity
             case DIALOG_GET_FROM_MARKET:
                 return new DownloadOIAppDialog(this,
                         DownloadOIAppDialog.OI_BARCODESCANNER);
+            default:
+                break;
         }
         return super.onCreateDialog(id);
 
@@ -2528,6 +2536,8 @@ public class ShoppingActivity extends DistributionLibraryFragmentActivity
                 break;
             case DIALOG_GET_FROM_MARKET:
                 DownloadOIAppDialog.onPrepareDialog(this, dialog);
+                break;
+            default:
                 break;
         }
     }
@@ -3164,6 +3174,9 @@ public class ShoppingActivity extends DistributionLibraryFragmentActivity
                         v = mInflater.inflate(R.layout.drawer_item_header, parent, false);
                         ((TextView) v).setText(R.string.list); // fix me
                         break;
+                    default:
+                        break;
+                    
                 }
             } else if ((list_pos = position - mNumAboveList) < list_count) {
                 int curListPos = mShoppingListsView.getSelectedItemPosition();

--- a/ShoppingList/src/main/java/org/openintents/shopping/ui/dialog/EditItemDialog.java
+++ b/ShoppingList/src/main/java/org/openintents/shopping/ui/dialog/EditItemDialog.java
@@ -425,6 +425,8 @@ public class EditItemDialog extends AlertDialog implements OnClickListener {
             case ITEMNAME:
                 focus_field(mEditText, false);
                 break;
+            default:
+                break;
 
         }
     }

--- a/ShoppingList/src/main/java/org/openintents/shopping/ui/widget/ShoppingItemsView.java
+++ b/ShoppingList/src/main/java/org/openintents/shopping/ui/widget/ShoppingItemsView.java
@@ -1539,6 +1539,8 @@ public class ShoppingItemsView extends ListView implements LoaderManager.LoaderC
                         mUpperBound = Math.min(y - touchSlop, mHeight / 3);
                         mLowerBound = Math.max(y + touchSlop, mHeight * 2 / 3);
                         return false;
+                    default:
+                        break;
                 }
             }
         }
@@ -1699,6 +1701,8 @@ public class ShoppingItemsView extends ListView implements LoaderManager.LoaderC
                             }
                         }
                     }
+                    break;
+                default:
                     break;
             }
             return true;

--- a/ShoppingList/src/myo/java/org/openintents/shopping/ui/MyoToggleBoughtInputMethod.java
+++ b/ShoppingList/src/myo/java/org/openintents/shopping/ui/MyoToggleBoughtInputMethod.java
@@ -49,7 +49,8 @@ public class MyoToggleBoughtInputMethod implements ToggleBoughtInputMethod {
                     position--;
                     itemsView.setSelection(position);
                     break;
-
+                default:
+                    break;
             }
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.

M-Ezzat