### PR TITLE
squid:S1197 - Array designators should be on the type, not the variable

### DIFF
--- a/ShoppingList/src/main/java/org/openintents/provider/Alert.java
+++ b/ShoppingList/src/main/java/org/openintents/provider/Alert.java
@@ -412,7 +412,7 @@ public class Alert {
         String distStr = "";
 
         String geo = "";
-        String loc[] = null;
+        String[] loc = null;
 
         try {
             gUri = Uri.parse(cv.getAsString(Location.POSITION));
@@ -463,7 +463,7 @@ public class Alert {
     public static void registerDateTimeAlert(ContentValues cv) {
 
         String myDate = cv.getAsString(DateTime.TIME);
-        String s[] = myDate.split(",");
+        String[] s = myDate.split(",");
         Log.d(_TAG, "registerDateTimeAlert: s[0]>>" + s[0] + "<< s[1]>>+"
                 + s[1] + "<<");
         long time = 0;

--- a/ShoppingList/src/main/java/org/openintents/shopping/ui/PreferenceActivity.java
+++ b/ShoppingList/src/main/java/org/openintents/shopping/ui/PreferenceActivity.java
@@ -116,11 +116,11 @@ public class PreferenceActivity extends android.preference.PreferenceActivity
 
     public static final String EXTRA_SHOW_GET_ADD_ONS = "show_get_add_ons";
 
-    private static final TextKeyListener.Capitalize smCapitalizationSettings[] = {
+    private static final TextKeyListener.Capitalize[] smCapitalizationSettings = {
             TextKeyListener.Capitalize.NONE,
             TextKeyListener.Capitalize.SENTENCES,
             TextKeyListener.Capitalize.WORDS};
-    private static final int smCapitalizationInputTypes[] = {
+    private static final int[] smCapitalizationInputTypes = {
             InputType.TYPE_CLASS_TEXT,
             InputType.TYPE_TEXT_FLAG_CAP_SENTENCES,
             InputType.TYPE_TEXT_FLAG_CAP_WORDS};
@@ -301,7 +301,7 @@ public class PreferenceActivity extends android.preference.PreferenceActivity
 
     private void updatePrioSubtotalSummary(SharedPreferences prefs) {
         int threshold = getSubtotalByPriorityThreshold(prefs);
-        CharSequence labels[] = mPrioSubtotal.getEntries();
+        CharSequence[] labels = mPrioSubtotal.getEntries();
         mPrioSubtotal.setSummary(labels[threshold]);
         mIncludesChecked.setEnabled(threshold != 0);
     }

--- a/ShoppingList/src/main/java/org/openintents/shopping/ui/ShoppingActivity.java
+++ b/ShoppingList/src/main/java/org/openintents/shopping/ui/ShoppingActivity.java
@@ -3282,9 +3282,9 @@ public class ShoppingActivity extends DistributionLibraryFragmentActivity
     private class ListSortActionProvider extends ActionProvider implements OnMenuItemClickListener {
 
         private Context mContext;
-        private String mSortLabels[];
-        private String mSortVals[];
-        private Integer mSortValInts[];
+        private String[] mSortLabels;
+        private String[] mSortVals;
+        private Integer[] mSortValInts;
 
         public ListSortActionProvider(Context context) {
             super(context);

--- a/ShoppingList/src/main/java/org/openintents/shopping/ui/ShoppingTotalsHandler.java
+++ b/ShoppingList/src/main/java/org/openintents/shopping/ui/ShoppingTotalsHandler.java
@@ -147,7 +147,7 @@ public class ShoppingTotalsHandler implements LoaderManager.LoaderCallbacks<Curs
         }
 
         if (priority_total != 0) {
-            final int captions[] = {0, R.string.priority1_total, R.string.priority2_total,
+            final int[] captions = {0, R.string.priority1_total, R.string.priority2_total,
                     R.string.priority3_total, R.string.priority4_total};
             String s = mPriceFormatter.format(priority_total * 0.01d);
             s = mActivity.getString(captions[priority_threshold], s);

--- a/ShoppingList/src/main/java/org/openintents/shopping/ui/SnackbarUndoMultipleItemStatusOperation.java
+++ b/ShoppingList/src/main/java/org/openintents/shopping/ui/SnackbarUndoMultipleItemStatusOperation.java
@@ -24,9 +24,9 @@ public class SnackbarUndoMultipleItemStatusOperation extends SnackbarUndoOperati
     public static final int MARK_ALL = 1;
     public static final int CLEAN_LIST = 2;
 
-    private long old_status[] = {ShoppingContract.Status.BOUGHT,
+    private long[] old_status = {ShoppingContract.Status.BOUGHT,
             ShoppingContract.Status.WANT_TO_BUY, ShoppingContract.Status.BOUGHT};
-    private int resIds[] = {R.plurals.undoable_unmark_all, R.plurals.undoable_mark_all,
+    private int[] resIds = {R.plurals.undoable_unmark_all, R.plurals.undoable_mark_all,
             R.plurals.undoable_clean_list};
 
     private final ShoppingItemsView mShoppingItemsView;

--- a/ShoppingList/src/main/java/org/openintents/shopping/ui/widget/ShoppingItemsView.java
+++ b/ShoppingList/src/main/java/org/openintents/shopping/ui/widget/ShoppingItemsView.java
@@ -294,7 +294,7 @@ public class ShoppingItemsView extends ListView implements LoaderManager.LoaderC
             state.mCursor = cursor;
 
             // set style for name view and friends
-            TextView styled_as_name[] = {state.mNameView, state.mUnitsView, state.mQuantityView};
+            TextView[] styled_as_name = {state.mNameView, state.mUnitsView, state.mQuantityView};
             int i;
             for (i = 0; i < styled_as_name.length; i++) {
                 TextView t = styled_as_name[i];


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1197 - Array designators "[]" should be on the type, not the variable

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.

M-Ezzat