### PR TITLE
Show item name in delete confirmation dialog

### DIFF
--- a/ShoppingList/src/main/java/org/openintents/shopping/ui/ShoppingActivity.java
+++ b/ShoppingList/src/main/java/org/openintents/shopping/ui/ShoppingActivity.java
@@ -2528,6 +2528,21 @@ public class ShoppingActivity extends DistributionLibraryFragmentActivity
             case DIALOG_GET_FROM_MARKET:
                 DownloadOIAppDialog.onPrepareDialog(this, dialog);
                 break;
+            case DIALOG_DELETE_ITEM:
+                if (mItemsView != null && dialog instanceof AlertDialog) {
+                    ListAdapter adapter = mItemsView.getAdapter();
+                    if (adapter != null && adapter instanceof CursorAdapter) {
+                        Cursor c = (Cursor) adapter.getItem(mDeleteItemPosition);
+                        if (c != null) {
+                            String itemName = c.getString(mStringItemsITEMNAME);
+                            if (itemName != null) {
+                                ((AlertDialog) dialog).setMessage(
+                                        getResources().getString(R.string.delete_item_confirm, itemName));
+                            }
+                        }
+                    }
+                }
+                break;
             default:
                 break;
         }

--- a/ShoppingList/src/main/res/values-da/strings.xml
+++ b/ShoppingList/src/main/res/values-da/strings.xml
@@ -119,7 +119,7 @@ Launchpad Contributions:
   <string name="priority3_total">Priority 1-3: %s</string>
   <string name="priority4_total">Priority 1-4: %s</string>
 
-  <string name="delete_item_confirm">Are you sure you want to permanently delete this item?</string>
+  <string name="delete_item_confirm">Are you sure you want to permanently delete the item \"%s\"?</string>
   <string name="delete">Delete</string>
 
   <!-- Added to an item to indicate it was bought. -->

--- a/ShoppingList/src/main/res/values-de/strings.xml
+++ b/ShoppingList/src/main/res/values-de/strings.xml
@@ -129,7 +129,7 @@
   <string name="priority3_total">Wichtig 1-3: %s</string>
   <string name="priority4_total">Wichtig 1-4: %s</string>
 
-  <string name="delete_item_confirm">Sind Sie sicher, dass Sie dieses Element dauerhaft löschen möchten?</string>
+  <string name="delete_item_confirm">Sind Sie sicher, dass Sie das Element \"%s\" dauerhaft löschen möchten?</string>
   <string name="delete">Löschen</string>
 
   <!-- Added to an item to indicate it was bought. -->

--- a/ShoppingList/src/main/res/values-en-rGB/strings.xml
+++ b/ShoppingList/src/main/res/values-en-rGB/strings.xml
@@ -120,7 +120,7 @@
   <string name="priority3_total">Priority 1-3: %s</string>
   <string name="priority4_total">Priority 1-4: %s</string>
 
-  <string name="delete_item_confirm">Are you sure you want to permanently delete this item?</string>
+  <string name="delete_item_confirm">Are you sure you want to permanently delete the item \"%s\"?</string>
   <string name="delete">Delete</string>
 
   <!-- Added to an item to indicate it was bought. -->

--- a/ShoppingList/src/main/res/values-fr/strings.xml
+++ b/ShoppingList/src/main/res/values-fr/strings.xml
@@ -130,7 +130,7 @@
   <string name="priority3_total">Priorité 1-3: %s</string>
   <string name="priority4_total">Priorité 1-4: %s</string>
 
-  <string name="delete_item_confirm">Voulez-vous vraiment supprimer définitivement cet élément ?</string>
+  <string name="delete_item_confirm">Voulez-vous vraiment supprimer définitivement l\'élément \"%s\"?</string>
   <string name="delete">Supprimer</string>
 
   <!-- Added to an item to indicate it was bought. -->

--- a/ShoppingList/src/main/res/values-hr/strings.xml
+++ b/ShoppingList/src/main/res/values-hr/strings.xml
@@ -119,7 +119,7 @@
   <string name="priority3_total">Priority 1-3: %s</string>
   <string name="priority4_total">Priority 1-4: %s</string>
 
-  <string name="delete_item_confirm">Are you sure you want to permanently delete this item?</string>
+  <string name="delete_item_confirm">Are you sure you want to permanently delete the item \"%s\"?</string>
   <string name="delete">Obriši</string>
 
   <!-- Added to an item to indicate it was bought. -->

--- a/ShoppingList/src/main/res/values-hu/strings.xml
+++ b/ShoppingList/src/main/res/values-hu/strings.xml
@@ -117,7 +117,7 @@
   <string name="priority3_total">Priority 1-3: %s</string>
   <string name="priority4_total">Priority 1-4: %s</string>
 
-  <string name="delete_item_confirm">Are you sure you want to permanently delete this item?</string>
+  <string name="delete_item_confirm">Are you sure you want to permanently delete the item \"%s\"?</string>
   <string name="delete">Törlés</string>
 
   <!-- Added to an item to indicate it was bought. -->

--- a/ShoppingList/src/main/res/values-iw/strings.xml
+++ b/ShoppingList/src/main/res/values-iw/strings.xml
@@ -120,7 +120,7 @@
   <string name="priority3_total">עדיפות 1-3: %s</string>
   <string name="priority4_total">עדיפות 1-4: %s</string>
 
-  <string name="delete_item_confirm">Are you sure you want to permanently delete this item?</string>
+  <string name="delete_item_confirm">Are you sure you want to permanently delete the item \"%s\"?</string>
   <string name="delete">מחק</string>
 
   <!-- Added to an item to indicate it was bought. -->

--- a/ShoppingList/src/main/res/values-ko/strings.xml
+++ b/ShoppingList/src/main/res/values-ko/strings.xml
@@ -119,7 +119,7 @@
   <string name="priority3_total">우선순위 1-3: %s</string>
   <string name="priority4_total">우선순위 1-4: %s</string>
 
-  <string name="delete_item_confirm">Are you sure you want to permanently delete this item?</string>
+  <string name="delete_item_confirm">Are you sure you want to permanently delete the item \"%s\"?</string>
   <string name="delete">삭제</string>
 
   <!-- Added to an item to indicate it was bought. -->

--- a/ShoppingList/src/main/res/values-mk/strings.xml
+++ b/ShoppingList/src/main/res/values-mk/strings.xml
@@ -119,7 +119,7 @@
   <string name="priority3_total">Priority 1-3: %s</string>
   <string name="priority4_total">Priority 1-4: %s</string>
 
-  <string name="delete_item_confirm">Are you sure you want to permanently delete this item?</string>
+  <string name="delete_item_confirm">Are you sure you want to permanently delete the item \"%s\"?</string>
   <string name="delete">Избриши</string>
 
   <!-- Added to an item to indicate it was bought. -->

--- a/ShoppingList/src/main/res/values-oc/strings.xml
+++ b/ShoppingList/src/main/res/values-oc/strings.xml
@@ -117,7 +117,7 @@
   <string name="priority3_total">Priority 1-3: %s</string>
   <string name="priority4_total">Priority 1-4: %s</string>
 
-  <string name="delete_item_confirm">Are you sure you want to permanently delete this item?</string>
+  <string name="delete_item_confirm">Are you sure you want to permanently delete the item \"%s\"?</string>
   <string name="delete">Suprimir</string>
 
   <!-- Added to an item to indicate it was bought. -->

--- a/ShoppingList/src/main/res/values-pt-rBR/strings.xml
+++ b/ShoppingList/src/main/res/values-pt-rBR/strings.xml
@@ -117,7 +117,7 @@
   <string name="priority3_total">Priority 1-3: %s</string>
   <string name="priority4_total">Priority 1-4: %s</string>
 
-  <string name="delete_item_confirm">Are you sure you want to permanently delete this item?</string>
+  <string name="delete_item_confirm">Are you sure you want to permanently delete the item \"%s\"?</string>
   <string name="delete">Excluir</string>
 
   <!-- Added to an item to indicate it was bought. -->

--- a/ShoppingList/src/main/res/values-ru/strings.xml
+++ b/ShoppingList/src/main/res/values-ru/strings.xml
@@ -124,7 +124,7 @@
   <string name="priority3_total">Приоритет 1-3: %s</string>
   <string name="priority4_total">Приоритет 1-4: %s</string>
 
-  <string name="delete_item_confirm">Are you sure you want to permanently delete this item?</string>
+  <string name="delete_item_confirm">Are you sure you want to permanently delete the item \"%s\"?</string>
   <string name="delete">Удалить</string>
 
   <!-- Added to an item to indicate it was bought. -->

--- a/ShoppingList/src/main/res/values-tr/strings.xml
+++ b/ShoppingList/src/main/res/values-tr/strings.xml
@@ -123,7 +123,7 @@ Launchpad Contributions:
   <string name="priority3_total">Öncelik 1-3: %s</string>
   <string name="priority4_total">Öncelik 1-4:%s</string>
 
-  <string name="delete_item_confirm">Are you sure you want to permanently delete this item?</string>
+  <string name="delete_item_confirm">Are you sure you want to permanently delete the item \"%s\"?</string>
   <string name="delete">Sil</string>
 
   <!-- Added to an item to indicate it was bought. -->

--- a/ShoppingList/src/main/res/values-zh-rTW/strings.xml
+++ b/ShoppingList/src/main/res/values-zh-rTW/strings.xml
@@ -118,7 +118,7 @@
   <string name="priority3_total">Priority 1-3: %s</string>
   <string name="priority4_total">Priority 1-4: %s</string>
 
-  <string name="delete_item_confirm">Are you sure you want to permanently delete this item?</string>
+  <string name="delete_item_confirm">Are you sure you want to permanently delete the item \"%s\"?</string>
   <string name="delete">Delete</string>
 
   <!-- Added to an item to indicate it was bought. -->

--- a/ShoppingList/src/main/res/values/strings.xml
+++ b/ShoppingList/src/main/res/values/strings.xml
@@ -123,7 +123,7 @@
   <string name="priority3_total">Priority 1-3: %s</string>
   <string name="priority4_total">Priority 1-4: %s</string>
 
-  <string name="delete_item_confirm">Are you sure you want to permanently delete this item?</string>
+  <string name="delete_item_confirm">Are you sure you want to permanently delete the item \"%s\"?</string>
   <string name="delete">Delete</string>
 
   <!-- Added to an item to indicate it was bought. -->


### PR DESCRIPTION
Sorry need to re-open this because the underlying branch was deleted.
Original text:
I always found it risky to delete items because the confirmation dialog would not show me which item I was about to delete. This patch makes the item name show in the confirmation dialog box.

