### PR TITLE
Fix: radio button in left drawer not updating (#49)

### DIFF
--- a/ShoppingList/src/main/java/org/openintents/shopping/ui/ShoppingActivity.java
+++ b/ShoppingList/src/main/java/org/openintents/shopping/ui/ShoppingActivity.java
@@ -3230,8 +3230,8 @@ public class ShoppingActivity extends DistributionLibraryFragmentActivity
                 mItemsView.mMode = (position == 1) ? MODE_ADD_ITEMS : MODE_IN_SHOP;
                 mDrawerListsView.setItemChecked(position, true);
                 mDrawerListsView.setItemChecked(1 - position, false);
+                mDrawerListsView.invalidateViews();
                 onModeChanged();
-                // need to toggle the radio buttons too
             } else if ((list_pos = position - mNumAboveList) < list_count) {
                 // Update list cursor:
                 mShoppingListsView.setSelection(list_pos);


### PR DESCRIPTION
Refresh UI so that radio button is actually toggled when changing shopping mode in left drawer. (Bug visible on Nougat and Oreo)